### PR TITLE
Add Test to Validate Mitigation of Unauthorized Bounty Claim

### DIFF
--- a/test/HoneyPause.t.sol
+++ b/test/HoneyPause.t.sol
@@ -512,11 +512,11 @@ contract HoneyPauseTest is Test {
         // Create a fake bounty attempting to use the first bounty's pauser/payer with an always successful Verifyer
         uint256 fakeBountyId = honey.add("BogusExploitTest", testToken, bountyAmount, new TestVerifier(), mockPauser, mockPayer, address(this));
 
+        IExploiter exploiter = new TestExploiter();
+
         // Set the bountyId in mock contracts to the valid bountyId
         mockPauser.setValidBountyId(legitimateBountyId);
         mockPayer.setValidBountyId(legitimateBountyId);
-
-        IExploiter exploiter = new TestExploiter();
 
         // Expecting failure due to bountyId checks in the impl of IPauser IPayer
         vm.expectRevert("Unauthorized bountyId");
@@ -574,8 +574,8 @@ contract HoneyPauseTest is Test {
 contract MockPauser is IPauser {
     uint256 private validBountyId;
 
-    function setValidBountyId(uint256 _validBountyId) external {
-        validBountyId = _validBountyId;
+    function setValidBountyId(uint256 validBountyId_) external {
+        validBountyId = validBountyId_;
     }
 
     function pause(uint256 bountyId) external view {

--- a/test/HoneyPause.t.sol
+++ b/test/HoneyPause.t.sol
@@ -594,7 +594,7 @@ contract MockPayer is IPayer {
 
     function payExploiter(uint256 bountyId, ERC20 token, address payable to, uint256 amount) external override {
         require(bountyId == validBountyId, "Unauthorized bountyId");
-        require(token.transfer(to, amount), "Transfer failed");
+        token.transfer(to, amount);
     }
 }
 

--- a/test/HoneyPause.t.sol
+++ b/test/HoneyPause.t.sol
@@ -509,7 +509,7 @@ contract HoneyPauseTest is Test {
         uint256 bountyAmount = 1 ether;
         uint256 legitimateBountyId = honey.add("LegitimateExploitTest", testToken, bountyAmount, new TestVerifier(), mockPauser, mockPayer, address(this));
 
-        // Create a fake bounty attempting to use the first bounty's pauser/payer with an always successful Verifyer
+        // Create a fake bounty attempting to use the first bounty's pauser/payer with an always successful Verifier
         uint256 fakeBountyId = honey.add("BogusExploitTest", testToken, bountyAmount, new TestVerifier(), mockPauser, mockPayer, address(this));
 
         IExploiter exploiter = new TestExploiter();

--- a/test/HoneyPause.t.sol
+++ b/test/HoneyPause.t.sol
@@ -588,8 +588,8 @@ contract MockPauser is IPauser {
 contract MockPayer is IPayer {
     uint256 private validBountyId;
 
-    function setValidBountyId(uint256 _validBountyId) external {
-        validBountyId = _validBountyId;
+    function setValidBountyId(uint256 validBountyId_) external {
+        validBountyId = validBountyId_;
     }
 
     function payExploiter(uint256 bountyId, ERC20 token, address payable to, uint256 amount) external override {

--- a/test/HoneyPause.t.sol
+++ b/test/HoneyPause.t.sol
@@ -503,7 +503,6 @@ contract HoneyPauseTest is Test {
         MockPauser mockPauser = new MockPauser();
         MockPayer mockPayer = new MockPayer();
 
-        testToken.mint(address(mockPayer), 100 ether);
         uint256 bountyAmount = 1 ether;
 
         // Create legitimate and a fake bounty with the mock contracts.
@@ -534,14 +533,14 @@ contract HoneyPauseTest is Test {
         mockPayer.setValidBountyId(legitimateBountyId); 
 
         // Test that the pauser receives the correct bountyId and reverts against the fake bountyId.
-        vm.expectRevert("Unauthorized bountyId");
+        vm.expectRevert("Unauthorized bountyId in pauser");
         honey.claim(fakeBountyId, payable(address(this)), exploiter, "", "");
 
         // Temporarily allow pausing for the fake bounty to test payer logic.
         mockPauser.setValidBountyId(fakeBountyId); 
 
         // Test that the payer also correctly identifies and reverts against fake bountyId claims.
-        vm.expectRevert("Unauthorized bountyId");
+        vm.expectRevert("Unauthorized bountyId in payer");
         honey.claim(fakeBountyId, payable(address(this)), exploiter, "", "");
     }
 
@@ -598,7 +597,7 @@ contract MockPauser is IPauser {
     }
 
     function pause(uint256 bountyId) external view {
-        require(bountyId == validBountyId, "Unauthorized bountyId");
+        require(bountyId == validBountyId, "Unauthorized bountyId in pauser");
     }
 }
 
@@ -610,7 +609,7 @@ contract MockPayer is IPayer {
     }
 
     function payExploiter(uint256 bountyId, ERC20 token, address payable to, uint256 amount) external override {
-        require(bountyId == validBountyId, "Unauthorized bountyId");
+        require(bountyId == validBountyId, "Unauthorized bountyId in payer");
         token.transfer(to, amount);
     }
 }


### PR DESCRIPTION
Added new test to ensure that only authorized bounties can trigger certain actions in the HoneyPause contract.